### PR TITLE
declare gksdud as global

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,8 +28,6 @@ plugins=(
     git
 +   zsh-hangul
 )
-
-+source $ZSH/custom/plugins/zsh-hangul/zsh-hangul.plugin.zsh
 ```
 
 과 같이 zsh-hangul을 추가해주세요.

--- a/hangul-map.zsh
+++ b/hangul-map.zsh
@@ -1,4 +1,4 @@
-typeset -A gksdud
+typeset -gA gksdud
 gksdud[ㄱ]="r"
 gksdud[ㄲ]="R"
 gksdud[ㄳ]="rt"


### PR DESCRIPTION
Fix #16 

## 현상
- Mac: 'ㄴ' 타이핑 시 `_convert_gksdud:9: bad math expression: operand expected at 'ㄴ'` 발생
  - #16 
- Ubuntu: 한글 타이핑 시 공백으로 치환 또는 글자가 사라짐

> 구체적인 환경과 실제 현상은 조금씩 차이가 있을 수 있음

## 원인
ohmyzsh에서 plugin을 source하는 방식이 변경됨 ohmyzsh/ohmyzsh#11550
- 기존에는 `$ZSH/oh-my-zsh.sh`가 `source "$ZSH_CUSTOM/plugins/$plugin/$plugin.plugin.zsh"`을 직접 호출하였으나, 위 PR을 통해 _omz_source 함수를 정의하고 그 안에서 이를 처리하도록 변경되었음. 이로 인해 gksdud이 _omz_source 스코프 내의 로컬 변수가 되어버리면서, _convert_gksdud에서 `gksdud[${KEYS}]`를 읽는 과정에서 `gksdud`이 없는 이슈 발생
### 검증
- plugins에서 제외하고 직접 `source $ZSH/custom/plugins/zsh-hangul/zsh-hangul.plugin.zsh`하거나(#17),
- plugins에는 포함하되 gksdud을 정의하는 `source $ZSH/custom/plugins/zsh-hangul/hangul-map.zsh`를 해주면 정상적으로 동작함을 확인하였음


## 해결
hangul-map.zsh에서 gksdud을 global로 정의하도록 변경